### PR TITLE
Check `mediaUrl` against proper regexes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@
   var REGEX_WISTIA = /^https?:\/\/\w+\.wistia\.com\/medias\/(.+)/;
   var REGEX_MESSAGE_TOKEN = /\*(.*?)\*/g;
   var DEFAULT_BUTTON_TEXT = '▶♫';
- 
+
   //--------------------------------------------------
   // Plugin
   //--------------------------------------------------
@@ -85,7 +85,7 @@
     componentWillUnmount(editor);
     element.parentNode.removeChild(element);
   }
- 
+
   /**
    * Lifecycle method to handle the component being removed from the DOM
    *
@@ -93,7 +93,7 @@
    */
   function componentWillUnmount(editor) {
     var element = getDOMNode(editor);
-    
+
     element.ondragover = null;
     element.ondragend = null;
     element.ondrop = null;
@@ -224,13 +224,13 @@
     }
 
     return [
-      new EmbedMatcher(REGEX_TYPE_VIDEO, function (mediaUrl) {
-        return createMedia('video', mediaUrl);  
+      new EmbedMatcher(REGEX_VIDEO, function (mediaUrl) {
+        return createMedia('video', mediaUrl);
       }),
-      new EmbedMatcher(REGEX_TYPE_IMAGE, function (mediaUrl) {
+      new EmbedMatcher(REGEX_IMAGE, function (mediaUrl) {
         return createMedia('img', mediaUrl);
       }),
-      new EmbedMatcher(REGEX_TYPE_AUDIO, function (mediaUrl) {
+      new EmbedMatcher(REGEX_AUDIO, function (mediaUrl) {
         return createMedia('audio', mediaUrl);
       }),
       new EmbedMatcher(REGEX_YOUTUBE, function (mediaUrl, parentNode) {
@@ -296,7 +296,7 @@
 
     var element = getDOMNode(editor);
     var media = null;
-    
+
     for (var i=0, l=matchers.length; i<l; i++) {
       var matcher = matchers[i];
       if (matcher.regex.test(mediaUrl)) {


### PR DESCRIPTION
Previously this would test the url against the mime-type regexes, this
changes it to test against the file extension regexes.

The demo was working because "image" is in the URL.
