### PR TITLE
Add editor command for use via external scripting

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@
   var REGEX_WISTIA = /^https?:\/\/\w+\.wistia\.com\/medias\/(.+)/;
   var REGEX_MESSAGE_TOKEN = /\*(.*?)\*/g;
   var DEFAULT_BUTTON_TEXT = '▶♫';
- 
+
   //--------------------------------------------------
   // Plugin
   //--------------------------------------------------
@@ -22,20 +22,24 @@
     var image = getParam(editor, 'button_image');
     var text = getMessage(editor, 'button_text', DEFAULT_BUTTON_TEXT);
 
+    editor.addCommand('InsertMediaUploader', function() {
+      // Only allow one at a time
+      var element = getDOMNode(editor);
+      if (element) {
+        element.focus();
+        return;
+      }
+
+      renderComponent(editor);
+      componentDidMount(editor);
+    });
+
     editor.addButton('mediauploader', {
       image: image,
       title: getMessage(editor, 'button_title', 'Upload Media'),
       text: (image && text === DEFAULT_BUTTON_TEXT) ? null : text,
       onclick: function () {
-        // Only allow one at a time
-        var element = getDOMNode(editor);
-        if (element) {
-          element.focus();
-          return;
-        }
-
-        renderComponent(editor);
-        componentDidMount(editor);
+        editor.execCommand('InsertMediaUploader');
       }
     });
   });
@@ -85,7 +89,7 @@
     componentWillUnmount(editor);
     element.parentNode.removeChild(element);
   }
- 
+
   /**
    * Lifecycle method to handle the component being removed from the DOM
    *
@@ -93,7 +97,7 @@
    */
   function componentWillUnmount(editor) {
     var element = getDOMNode(editor);
-    
+
     element.ondragover = null;
     element.ondragend = null;
     element.ondrop = null;
@@ -225,7 +229,7 @@
 
     return [
       new EmbedMatcher(REGEX_TYPE_VIDEO, function (mediaUrl) {
-        return createMedia('video', mediaUrl);  
+        return createMedia('video', mediaUrl);
       }),
       new EmbedMatcher(REGEX_TYPE_IMAGE, function (mediaUrl) {
         return createMedia('img', mediaUrl);
@@ -296,7 +300,7 @@
 
     var element = getDOMNode(editor);
     var media = null;
-    
+
     for (var i=0, l=matchers.length; i<l; i++) {
       var matcher = matchers[i];
       if (matcher.regex.test(mediaUrl)) {


### PR DESCRIPTION
This change makes it so the toolbar is optional for using the plugin. The button still gets added if you want to use the toolbar, but additionally, you can use `execCommand` so that its use can be scripted via an external UI.
