### PR TITLE
Remove mediauploader_style_url option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ tinymce.init({
   plugins: 'link mediauploader',
   toolbar: 'bold italic bullist numlist link mediauploader',
 
+  // Path to CSS file to customize plugin widget appearance, see 
+  // `lib/styles.css` for available selectors and example styling
+  //
+  // http://www.tinymce.com/wiki.php/Configuration:content_css for more info
+  content_css: '//example.com/path/to/style.css'
+
   /**
     * Handle a file being uploaded by the plugin
     *
@@ -35,10 +41,7 @@ tinymce.init({
         */
       callback('https://pbs.twimg.com/profile_images/2221189782/beavis_butthead.jpg');
     }, 2500);
-  },
-
-  // Path to CSS file to customize plugin widget appearance
-  mediauploader_style_url: '//example.com/path/to/style.css'
+  }
 });
 ```
 
@@ -53,12 +56,6 @@ This is the `function` that will handle files that need to be uploaded. See the 
 #### `mediauploader_embed_media`
 
 This `function` is called anytime media is embeded into the editor. It takes the media `element` as it's only argument.
-
-#### `mediauploader_style_url`
-
-**Required**
-
-No styling is provided automatically. A default stylesheet is provided under `lib/styles.css`, or you may customize your own theme. This URL is rendered in an iframe, so it must be a fully qualified URL.
 
 #### `mediauploader_button_image`
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -63,13 +63,13 @@
       menubar: false,
       plugins: 'link mediauploader',
       toolbar: 'bold italic bullist numlist link mediauploader',
+      content_css: '//127.0.0.1:3030/lib/styles.css',
       mediauploader_upload_file: function (widget, file, callback) {
         widget.innerHTML = 'Uploading...';
         setTimeout(function () {
           callback('https://pbs.twimg.com/profile_images/2221189782/beavis_butthead.jpg');
         }, 1000);
       },
-      mediauploader_style_url: '//127.0.0.1:3030/lib/styles.css',
       mediauploader_embed_media: function (media) {
         console.log(media);
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@
   var REGEX_WISTIA = /^https?:\/\/\w+\.wistia\.com\/medias\/(.+)/;
   var REGEX_MESSAGE_TOKEN = /\*(.*?)\*/g;
   var DEFAULT_BUTTON_TEXT = '▶♫';
- 
+
   //--------------------------------------------------
   // Plugin
   //--------------------------------------------------
@@ -85,7 +85,7 @@
     componentWillUnmount(editor);
     element.parentNode.removeChild(element);
   }
- 
+
   /**
    * Lifecycle method to handle the component being removed from the DOM
    *
@@ -93,7 +93,7 @@
    */
   function componentWillUnmount(editor) {
     var element = getDOMNode(editor);
-    
+
     element.ondragover = null;
     element.ondragend = null;
     element.ondrop = null;
@@ -117,15 +117,6 @@
     var doc = editor.iframeElement.contentDocument;
     var element = getDOMNode(editor);
     element.focus();
-
-    var styleUrl = getParam(editor, 'style_url');
-    if (styleUrl) {
-      var link = document.createElement('link');
-      link.setAttribute('rel', 'stylesheet');
-      link.setAttribute('type', 'text/css');
-      link.setAttribute('href', styleUrl);
-      doc.head.appendChild(link);
-    }
 
     document.addEventListener('dragover', eventPreventDefault);
     document.addEventListener('drop', eventPreventDefault);
@@ -225,7 +216,7 @@
 
     return [
       new EmbedMatcher(REGEX_TYPE_VIDEO, function (mediaUrl) {
-        return createMedia('video', mediaUrl);  
+        return createMedia('video', mediaUrl);
       }),
       new EmbedMatcher(REGEX_TYPE_IMAGE, function (mediaUrl) {
         return createMedia('img', mediaUrl);
@@ -296,7 +287,7 @@
 
     var element = getDOMNode(editor);
     var media = null;
-    
+
     for (var i=0, l=matchers.length; i<l; i++) {
       var matcher = matchers[i];
       if (matcher.regex.test(mediaUrl)) {


### PR DESCRIPTION
Added reference and links to TinyMCE's `content_css` to the README and
updated the example to use `content_css`.

Since this is already built into TinyMCE and it supports resolving relative URLs, I thought it'd be better to call it out in the docs rather thank keeping the functionality in the plugin.
